### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 Pillow
 setuptools
 six
-pytorch
+torch
 torchvision
 wheel


### PR DESCRIPTION
getting an error on python install -r requirements.txt, because pytorch is now called torch.
This commit fixing this!